### PR TITLE
Make the figure as part of make all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ spotless:	clean
 clean:
 		rm -f $(TAG).log
 
-all:		build-dcw tar-dcw zip-dcw checksum
+all:		build-dcw tar-dcw zip-dcw checksum fig
 
 checksum:
 		md5sum -r $(TAG)-$(DCW_VERSION).tar.gz | awk '{printf "Update $(TAG).info with the new check sum: %s\n", $$1}'


### PR DESCRIPTION
The docs for the make all target said that the figure is created, but this was left off of the make all command.