### PR TITLE
Add a clean VERSION file to the tarball and zip file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 #
 #	Author:	Paul Wessel, SOEST, U. of Hawaii
 #
-#	Update Date:	2-JAN-2019
+#	Update Date:	18-JAN-2022
 #
 #-------------------------------------------------------------------------------
 #	!! STOP EDITING HERE, THE REST IS FIXED !!
@@ -64,6 +64,7 @@ tar-dcw:
 		rm -rf $(TAG)-$(DCW_VERSION)
 		mkdir -p $(TAG)-$(DCW_VERSION)
 		cp -f $(TAG).nc dcw-collections.txt dcw-countries.txt dcw-states.txt LICENSE README.md ChangeLog $(TAG)-$(DCW_VERSION)
+		echo $(DCW_VERSION) > $(TAG)-$(DCW_VERSION)/VERSION
 		chmod -R og+r $(TAG)-$(DCW_VERSION)
 		COPYFILE_DISABLE=true $(GNUTAR) --owner 0 --group 0 --mode a=rX,u=rwX -czhvf $(TAG)-$(DCW_VERSION).tar.gz $(TAG)-$(DCW_VERSION)
 		rm -rf $(TAG)-$(DCW_VERSION)
@@ -74,6 +75,7 @@ zip-dcw:
 		rm -f $(TAG)-$(DCW_VERSION).zip
 		mkdir -p $(TAG)-$(DCW_VERSION)
 		cp -f $(TAG).nc dcw-collections.txt dcw-countries.txt dcw-states.txt LICENSE README.md ChangeLog $(TAG)-$(DCW_VERSION)
+		echo $(DCW_VERSION) > $(TAG)-$(DCW_VERSION)/VERSION
 		chmod -R og+r $(TAG)-$(DCW_VERSION)
 		zip -r -9 -q $(TAG)-$(DCW_VERSION).zip $(TAG)-$(DCW_VERSION)/$(TAG).nc
 		zip -r -9 -q -g -l $(TAG)-$(DCW_VERSION).zip \
@@ -81,6 +83,7 @@ zip-dcw:
 			$(TAG)-$(DCW_VERSION)/dcw-countries.txt \
 			$(TAG)-$(DCW_VERSION)/dcw-states.txt \
 			$(TAG)-$(DCW_VERSION)/LICENSE \
+			$(TAG)-$(DCW_VERSION)/VERSION \
 			$(TAG)-$(DCW_VERSION)/README.md \
 			$(TAG)-$(DCW_VERSION)/ChangeLog
 		rm -rf $(TAG)-$(DCW_VERSION)

--- a/config.mk
+++ b/config.mk
@@ -3,7 +3,7 @@
 #
 # These are the default settings.  You can override them by supplying your
 # own config.mk file which will take precedence.
-# Paul Wessel, Dec 2021
+# Paul Wessel, Jan 2022
 
 # DCW data version to be released:
 GMT_VERSION	= 6.1.1


### PR DESCRIPTION
In order to implement an automatic update of DCW from the server it will help to have a small file with the version number that we can download upon need so we can learn if there is a more recent version in the cloud.  I will manually copy over that file to the server for 2.1.0 for now.