### PR TITLE
Fix TW and HK in dcw-countries.txt

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,9 @@
         Contains changes made to the data files under dcw-gmt/orig etc
 -----------------------------------------------------------------------------------------
 
+2022-03-18	esteban82
+		Issue #73. Delete HK and add TW in dcw-countries.
+		
 2022-01-25	esteban82
 		Fix bug in MX. Issue #66.
 

--- a/dcw-countries.txt
+++ b/dcw-countries.txt
@@ -74,7 +74,6 @@ AS BT Bhutan
 AS CN China
 AS CX Christmas Island
 AS GE Georgia
-AS HK Hong Kong
 AS HM Heard Island and McDonald Islands
 AS ID Indonesia
 AS IL Israel
@@ -112,6 +111,7 @@ AS TJ Tajikistan
 AS TL Timor-Leste
 AS TM Turkmenistan
 AS TR Turkey
+AS TW Taiwan
 AS UZ Uzbekistan
 AS VN Viet Nam
 AS YE Yemen


### PR DESCRIPTION
Add TW in dcw-countries.txt and delete HK. In #56 I did it the other way around. Fix #71 .