### PR TITLE
dcw-collections. Add continental sectors.

### DIFF
--- a/dcw-collections.txt
+++ b/dcw-collections.txt
@@ -497,7 +497,7 @@ tag: CRC Continental Costa Rica
 region: 274.049382/277.443941/8.032905/11.216727
 tag: ECC Continental Ecuador
 region: 278.921186/284.815170/-4.998823/1.438945
-tag: PTC Continetal Portugal
+tag: PTC Continental Portugal
 region: -9.496163/-6.183121/36.961179/42.145478
 tag: ESC Continental Spain
 region: -9.290919/4.315019/35.185219/43.791472

--- a/dcw-collections.txt
+++ b/dcw-collections.txt
@@ -498,6 +498,6 @@ region: 274.049382/277.443941/8.032905/11.216727
 tag: ECC Continental Ecuador
 region: 278.921186/284.815170/-4.998823/1.438945
 tag: PTC Continental Portugal
-region: -9.496163/-6.183121/36.961179/42.145478
+region: -9.56/-6.18/36.955/42.16
 tag: ESC Continental Spain
 region: -9.290919/4.315019/35.185219/43.791472

--- a/dcw-collections.txt
+++ b/dcw-collections.txt
@@ -492,3 +492,12 @@ tag: GRSI Greater Sunda Islands
 region: 94/126/-9.6/7.6
 tag: ARTA Arctic Archipelago
 region: -128/-60/60/84
+# Continental sector of some countries
+tag: CRC Continental Costa Rica
+region: 274.049382/277.443941/8.032905/11.216727
+tag: ECC Continental Ecuador
+region: 278.921186/284.815170/-4.998823/1.438945
+tag: PTC Continetal Portugal
+region: -9.496163/-6.183121/36.961179/42.145478
+tag: ESC Continental Spain
+region: -9.290919/4.315019/35.185219/43.791472


### PR DESCRIPTION
Add the regions for the continental sector of Spain, Portugal, Ecuador and Costa Rica. 
The data was extracted from dcw (e.g. `gmt coast -EES -M -Df | gmt select -REurope | gmt info -Ie`).